### PR TITLE
Require https for social apis

### DIFF
--- a/lib/passport-yahoo-oauth/strategy.js
+++ b/lib/passport-yahoo-oauth/strategy.js
@@ -71,7 +71,7 @@ util.inherits(Strategy, OAuthStrategy);
  * @api protected
  */
 Strategy.prototype.userProfile = function(token, tokenSecret, params, done) {
-  this._oauth.get('http://social.yahooapis.com/v1/user/' + params.xoauth_yahoo_guid + '/profile?format=json', token, tokenSecret, function (err, body, res) {
+  this._oauth.get('https://social.yahooapis.com/v1/user/' + params.xoauth_yahoo_guid + '/profile?format=json', token, tokenSecret, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
     
     try {


### PR DESCRIPTION
http://yahoodevelopers.tumblr.com/post/75633763287/yahoo-contacts-and-profile-apis-move-to-https
