### PR TITLE
Minor Enhancements

### DIFF
--- a/lib/passport-yahoo-oauth/strategy.js
+++ b/lib/passport-yahoo-oauth/strategy.js
@@ -71,7 +71,7 @@ util.inherits(Strategy, OAuthStrategy);
  * @api protected
  */
 Strategy.prototype.userProfile = function(token, tokenSecret, params, done) {
-  this._oauth.get('http://social.yahooapis.com/v1/user/' + params.xoauth_yahoo_guid + '/profile?format=json', token, tokenSecret, function (err, body, res) {
+  this._oauth.get('https://social.yahooapis.com/v1/user/' + params.xoauth_yahoo_guid + '/profile?format=json', token, tokenSecret, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
     
     try {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "./lib/passport-yahoo-oauth",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth": "0.1.x"
+    "passport-oauth": "1.x.x"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
Bumps `passport-oauth` to `1.x.x`, which includes state management and other enhancements. Also explicitly makes `userProfile` fetching call over `https`.