### PR TITLE
Notice about incompatibility + new approach using passport-oauth2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Passport-Yahoo-OAuth
 
+| Notice (October 2022):       |
+| :------------- |
+| This module was designed for a previous version of Yahoo! OAuth API (v1.0a) and is no longer compatible with the current version of Yahoo! OAuth API (v2.0). A working alternative is to use [passport-oauth2](https://github.com/jaredhanson/passport-oauth2), configured to [Yahoo! OAuth API (v2.0) specifications](https://developer.yahoo.com/sign-in-with-yahoo/). Example code can be found [here](https://github.com/jaredhanson/passport-yahoo-oauth/tree/master/examples/example-oauth2). |
+
+---
+### Original README:
+---
+
 [Passport](http://passportjs.org/) strategies for authenticating with [Yahoo!](http://www.yahoo.com/)
 using the OAuth 1.0a API.
 

--- a/examples/example-oauth2/.env
+++ b/examples/example-oauth2/.env
@@ -1,0 +1,3 @@
+export yahooConsumerKey="yourConsumerKey"
+export yahooConsumerSecret="yourConsumerSecret"
+export yahooCallbackURL="yourCallbackURL"

--- a/examples/example-oauth2/passport.js
+++ b/examples/example-oauth2/passport.js
@@ -1,0 +1,41 @@
+var passport = require("passport");
+var OAuth2Strategy = require("passport-oauth2");
+var yahooConsumerKey = process.env.yahooConsumerKey;
+var yahooConsumerSecret = process.env.yahooConsumerSecret;
+var yahooCallbackURL = process.env.yahooCallbackURL;
+var fetch = require("node-fetch");
+
+passport.serializeUser(function (user, done) {
+    done(null, user);
+});
+
+passport.deserializeUser(function (user, done) {
+    done(null, user);
+});
+
+// ------------------------------------
+// Yahoo Login OAuth2 passport strategy
+// ------------------------------------
+passport.use(new OAuth2Strategy({
+    authorizationURL: `https://api.login.yahoo.com/oauth2/request_auth_fe?client_id=${yahooConsumerKey}&response_type=code&redirect_uri=${yahooCallbackURL}&language=en-US`,
+    tokenURL: "https://api.login.yahoo.com/oauth2/get_token",
+    clientID: yahooConsumerKey,
+    clientSecret: yahooConsumerSecret,
+    callbackURL: yahooCallbackURL
+},
+async function (accessToken, refreshToken, profile, cb) {
+    let authHead = "Bearer " + accessToken;
+    var profile = await fetch("https://api.login.yahoo.com/openid/v1/userinfo", {
+        method: "GET",
+        headers: {
+            "host": "api.login.yahoo.com",
+            "Authorization": authHead
+        }
+    })
+        .then(response => response.json())
+        .catch(error => console.log("error", error));
+    return cb(null, profile);
+}
+));
+
+module.exports = passport;

--- a/examples/example-oauth2/routes.js
+++ b/examples/example-oauth2/routes.js
@@ -1,0 +1,15 @@
+var passport = require("passport.js");
+
+module.exports = function (app) {
+
+    app.get("/auth/yahoo/callback",
+        passport.authenticate("oauth2", { failureRedirect: "/oauth-error", session: true }),
+        function (req, res) {
+            //
+            // Your code, post-authentication
+            //
+            // Example:
+            res.json(req.user);
+        });
+
+}


### PR DESCRIPTION
This pull request adds a notice to the readme about the module no longer being compatible and offers an alternative approach with example code that I had success with for authentication via Yahoo! OAuth API (v2.0) (by leveraging passport-oauth2).

May refactor the module in the future if time permits, but this seems to be a worthwhile update in the meantime.